### PR TITLE
fix: delete on restart and mem

### DIFF
--- a/crates/core/db/cold_state.rs
+++ b/crates/core/db/cold_state.rs
@@ -116,6 +116,16 @@ impl ColdState {
         Ok(())
     }
 
+    /// Append a tombstone for a deleted object so recovery skips it on restart.
+    pub fn append_tombstone(&self, namespace: &str, object_id: &str) -> Result<()> {
+        let micros = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros();
+        let mut log = self.trajectory_log.lock();
+        log.append_tombstone(micros, namespace, object_id)
+    }
+
     /// Force flush of the trajectory log to disk
     pub fn flush(&self) -> Result<()> {
         let mut log = self.trajectory_log.lock();
@@ -256,6 +266,8 @@ impl ColdState {
         let reader = BufReader::new(file);
 
         let mut latest_positions: HashMap<String, LocationUpdate> = HashMap::new();
+        // Tracks the timestamp of the most-recent tombstone per key.
+        let mut deleted_at: HashMap<String, SystemTime> = HashMap::new();
 
         for (line_num, line_result) in reader.lines().enumerate() {
             let line = match line_result {
@@ -270,8 +282,32 @@ impl ColdState {
                 }
             };
 
-            // Parse format: timestamp_micros|namespace|object_id|lat|lon|alt|json_len|json_metadata
             let parts: Vec<&str> = line.split('|').collect();
+
+            // Handle tombstone: TOMBSTONE|timestamp_micros|namespace|object_id
+            if parts.first() == Some(&"TOMBSTONE") {
+                if parts.len() != 4 {
+                    log::warn!("Malformed tombstone on line {}", line_num + 1);
+                    continue;
+                }
+                let ts_micros: u128 = match parts[1].parse() {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+                let ts = UNIX_EPOCH + std::time::Duration::from_micros(ts_micros as u64);
+                let key = format!("{}::{}", parts[2], parts[3]);
+                deleted_at
+                    .entry(key)
+                    .and_modify(|t| {
+                        if ts > *t {
+                            *t = ts;
+                        }
+                    })
+                    .or_insert(ts);
+                continue;
+            }
+
+            // Parse format: timestamp_micros|namespace|object_id|lat|lon|alt|json_len|json_metadata
             if parts.len() != 8 {
                 log::warn!(
                     "Malformed log line {} (expected 8 fields, got {})",
@@ -341,6 +377,13 @@ impl ColdState {
                 .or_insert(update);
         }
 
+        // Drop any objects whose most-recent log entry was a tombstone.
+        latest_positions.retain(|key, update| {
+            deleted_at
+                .get(key)
+                .is_none_or(|&ts| update.timestamp > ts)
+        });
+
         Ok(latest_positions)
     }
 }
@@ -403,6 +446,21 @@ impl TrajectoryLog {
             self.pending_writes = 0;
         }
 
+        Ok(())
+    }
+
+    fn append_tombstone(
+        &mut self,
+        micros: u128,
+        namespace: &str,
+        object_id: &str,
+    ) -> Result<()> {
+        writeln!(self.writer, "TOMBSTONE|{}|{}|{}", micros, namespace, object_id)?;
+        self.pending_writes += 1;
+        if self.pending_writes >= self.buffer_limit {
+            self.writer.flush()?;
+            self.pending_writes = 0;
+        }
         Ok(())
     }
 
@@ -561,6 +619,44 @@ mod tests {
         assert_eq!(plane.position.x(), -75.0);
         assert_eq!(plane.position.z(), 5000.0);
         assert_eq!(plane.timestamp, t3);
+    }
+
+    #[test]
+    fn test_tombstone_excludes_deleted_object_on_recovery() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("traj.log");
+        let cold = ColdState::new(&log_path, 10, PersistenceConfig { buffer_size: 0 }).unwrap();
+
+        let t1 = UNIX_EPOCH + Duration::from_secs(1000);
+        let t2 = UNIX_EPOCH + Duration::from_secs(2000);
+
+        cold.append_update("ns", "obj_keep", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), t1).unwrap();
+        cold.append_update("ns", "obj_del", Point3d::new(3.0, 4.0, 0.0), serde_json::json!({}), t1).unwrap();
+        cold.append_tombstone("ns", "obj_del").unwrap();
+        cold.append_update("ns", "obj_keep", Point3d::new(1.1, 2.1, 0.0), serde_json::json!({}), t2).unwrap();
+
+        let recovered = cold.recover_current_locations().unwrap();
+        assert!(recovered.contains_key("ns::obj_keep"), "kept object should be recovered");
+        assert!(!recovered.contains_key("ns::obj_del"), "deleted object must not be recovered");
+    }
+
+    #[test]
+    fn test_tombstone_then_reinsert_recovers_object() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("traj.log");
+        let cold = ColdState::new(&log_path, 10, PersistenceConfig { buffer_size: 0 }).unwrap();
+
+        let t1 = UNIX_EPOCH + Duration::from_secs(1000);
+        cold.append_update("ns", "obj", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), t1).unwrap();
+        cold.append_tombstone("ns", "obj").unwrap();
+
+        // Re-insert with a timestamp guaranteed to be after the tombstone (now + margin).
+        let t2 = SystemTime::now() + Duration::from_secs(1);
+        cold.append_update("ns", "obj", Point3d::new(5.0, 6.0, 0.0), serde_json::json!({}), t2).unwrap();
+
+        let recovered = cold.recover_current_locations().unwrap();
+        assert!(recovered.contains_key("ns::obj"), "re-inserted object should survive recovery");
+        assert_eq!(recovered["ns::obj"].position.x(), 5.0);
     }
 
     #[test]

--- a/crates/core/db/cold_state.rs
+++ b/crates/core/db/cold_state.rs
@@ -237,7 +237,7 @@ impl ColdState {
 
         // Merge buffer and disk results, sort by timestamp (newest first), limit
         from_buffer.extend(from_disk);
-        from_buffer.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        from_buffer.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
         from_buffer.truncate(limit);
 
         Ok(from_buffer)

--- a/crates/core/db/cold_state.rs
+++ b/crates/core/db/cold_state.rs
@@ -116,7 +116,6 @@ impl ColdState {
         Ok(())
     }
 
-    /// Append a tombstone for a deleted object so recovery skips it on restart.
     pub fn append_tombstone(&self, namespace: &str, object_id: &str) -> Result<()> {
         let micros = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -265,9 +264,11 @@ impl ColdState {
         let file = std::fs::File::open(path)?;
         let reader = BufReader::new(file);
 
-        let mut latest_positions: HashMap<String, LocationUpdate> = HashMap::new();
-        // Tracks the timestamp of the most-recent tombstone per key.
-        let mut deleted_at: HashMap<String, SystemTime> = HashMap::new();
+        struct RecoveryEntry {
+            best: Option<LocationUpdate>,
+        }
+
+        let mut entries: HashMap<String, RecoveryEntry> = HashMap::new();
 
         for (line_num, line_result) in reader.lines().enumerate() {
             let line = match line_result {
@@ -290,20 +291,11 @@ impl ColdState {
                     log::warn!("Malformed tombstone on line {}", line_num + 1);
                     continue;
                 }
-                let ts_micros: u128 = match parts[1].parse() {
-                    Ok(t) => t,
-                    Err(_) => continue,
-                };
-                let ts = UNIX_EPOCH + std::time::Duration::from_micros(ts_micros as u64);
                 let key = format!("{}::{}", parts[2], parts[3]);
-                deleted_at
+                entries
                     .entry(key)
-                    .and_modify(|t| {
-                        if ts > *t {
-                            *t = ts;
-                        }
-                    })
-                    .or_insert(ts);
+                    .or_insert(RecoveryEntry { best: None })
+                    .best = None;
                 continue;
             }
 
@@ -325,7 +317,8 @@ impl ColdState {
                     continue;
                 }
             };
-            let timestamp = UNIX_EPOCH + std::time::Duration::from_micros(timestamp_micros as u64);
+            let micros_u64 = u64::try_from(timestamp_micros).unwrap_or(u64::MAX);
+            let timestamp = UNIX_EPOCH + std::time::Duration::from_micros(micros_u64);
 
             let namespace = parts[1];
             let object_id = parts[2];
@@ -366,20 +359,22 @@ impl ColdState {
                 metadata,
             };
 
-            // Keep only the latest update for each object
-            latest_positions
+            let entry = entries
                 .entry(full_key)
-                .and_modify(|existing| {
-                    if update.timestamp > existing.timestamp {
-                        *existing = update.clone();
-                    }
-                })
-                .or_insert(update);
+                .or_insert(RecoveryEntry { best: None });
+            match &entry.best {
+                None => entry.best = Some(update),
+                Some(existing) if update.timestamp > existing.timestamp => {
+                    entry.best = Some(update);
+                }
+                _ => {}
+            }
         }
 
-        // Drop any objects whose most-recent log entry was a tombstone.
-        latest_positions
-            .retain(|key, update| deleted_at.get(key).is_none_or(|&ts| update.timestamp > ts));
+        let latest_positions = entries
+            .into_iter()
+            .filter_map(|(key, e)| e.best.map(|u| (key, u)))
+            .collect();
 
         Ok(latest_positions)
     }
@@ -615,6 +610,34 @@ mod tests {
         assert_eq!(plane.position.x(), -75.0);
         assert_eq!(plane.position.z(), 5000.0);
         assert_eq!(plane.timestamp, t3);
+    }
+
+    #[test]
+    fn test_tombstone_beats_future_timestamp_on_recovery() {
+        // An object inserted with a future SetOptions timestamp must still stay deleted
+        // after a tombstone is written, even though its timestamp is > current time.
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("traj.log");
+        let cold = ColdState::new(&log_path, 10, PersistenceConfig { buffer_size: 0 }).unwrap();
+
+        // Insert with a timestamp far in the future.
+        let future_ts = UNIX_EPOCH + Duration::from_secs(99_999_999_999);
+        cold.append_update(
+            "ns",
+            "obj",
+            Point3d::new(1.0, 2.0, 0.0),
+            serde_json::json!({}),
+            future_ts,
+        )
+        .unwrap();
+        // Tombstone written after the insert (later in log order).
+        cold.append_tombstone("ns", "obj").unwrap();
+
+        let recovered = cold.recover_current_locations().unwrap();
+        assert!(
+            !recovered.contains_key("ns::obj"),
+            "future-timestamped object must not reappear after tombstone"
+        );
     }
 
     #[test]

--- a/crates/core/db/cold_state.rs
+++ b/crates/core/db/cold_state.rs
@@ -378,11 +378,8 @@ impl ColdState {
         }
 
         // Drop any objects whose most-recent log entry was a tombstone.
-        latest_positions.retain(|key, update| {
-            deleted_at
-                .get(key)
-                .is_none_or(|&ts| update.timestamp > ts)
-        });
+        latest_positions
+            .retain(|key, update| deleted_at.get(key).is_none_or(|&ts| update.timestamp > ts));
 
         Ok(latest_positions)
     }
@@ -449,13 +446,12 @@ impl TrajectoryLog {
         Ok(())
     }
 
-    fn append_tombstone(
-        &mut self,
-        micros: u128,
-        namespace: &str,
-        object_id: &str,
-    ) -> Result<()> {
-        writeln!(self.writer, "TOMBSTONE|{}|{}|{}", micros, namespace, object_id)?;
+    fn append_tombstone(&mut self, micros: u128, namespace: &str, object_id: &str) -> Result<()> {
+        writeln!(
+            self.writer,
+            "TOMBSTONE|{}|{}|{}",
+            micros, namespace, object_id
+        )?;
         self.pending_writes += 1;
         if self.pending_writes >= self.buffer_limit {
             self.writer.flush()?;
@@ -630,14 +626,41 @@ mod tests {
         let t1 = UNIX_EPOCH + Duration::from_secs(1000);
         let t2 = UNIX_EPOCH + Duration::from_secs(2000);
 
-        cold.append_update("ns", "obj_keep", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), t1).unwrap();
-        cold.append_update("ns", "obj_del", Point3d::new(3.0, 4.0, 0.0), serde_json::json!({}), t1).unwrap();
+        cold.append_update(
+            "ns",
+            "obj_keep",
+            Point3d::new(1.0, 2.0, 0.0),
+            serde_json::json!({}),
+            t1,
+        )
+        .unwrap();
+        cold.append_update(
+            "ns",
+            "obj_del",
+            Point3d::new(3.0, 4.0, 0.0),
+            serde_json::json!({}),
+            t1,
+        )
+        .unwrap();
         cold.append_tombstone("ns", "obj_del").unwrap();
-        cold.append_update("ns", "obj_keep", Point3d::new(1.1, 2.1, 0.0), serde_json::json!({}), t2).unwrap();
+        cold.append_update(
+            "ns",
+            "obj_keep",
+            Point3d::new(1.1, 2.1, 0.0),
+            serde_json::json!({}),
+            t2,
+        )
+        .unwrap();
 
         let recovered = cold.recover_current_locations().unwrap();
-        assert!(recovered.contains_key("ns::obj_keep"), "kept object should be recovered");
-        assert!(!recovered.contains_key("ns::obj_del"), "deleted object must not be recovered");
+        assert!(
+            recovered.contains_key("ns::obj_keep"),
+            "kept object should be recovered"
+        );
+        assert!(
+            !recovered.contains_key("ns::obj_del"),
+            "deleted object must not be recovered"
+        );
     }
 
     #[test]
@@ -647,15 +670,32 @@ mod tests {
         let cold = ColdState::new(&log_path, 10, PersistenceConfig { buffer_size: 0 }).unwrap();
 
         let t1 = UNIX_EPOCH + Duration::from_secs(1000);
-        cold.append_update("ns", "obj", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), t1).unwrap();
+        cold.append_update(
+            "ns",
+            "obj",
+            Point3d::new(1.0, 2.0, 0.0),
+            serde_json::json!({}),
+            t1,
+        )
+        .unwrap();
         cold.append_tombstone("ns", "obj").unwrap();
 
         // Re-insert with a timestamp guaranteed to be after the tombstone (now + margin).
         let t2 = SystemTime::now() + Duration::from_secs(1);
-        cold.append_update("ns", "obj", Point3d::new(5.0, 6.0, 0.0), serde_json::json!({}), t2).unwrap();
+        cold.append_update(
+            "ns",
+            "obj",
+            Point3d::new(5.0, 6.0, 0.0),
+            serde_json::json!({}),
+            t2,
+        )
+        .unwrap();
 
         let recovered = cold.recover_current_locations().unwrap();
-        assert!(recovered.contains_key("ns::obj"), "re-inserted object should survive recovery");
+        assert!(
+            recovered.contains_key("ns::obj"),
+            "re-inserted object should survive recovery"
+        );
         assert_eq!(recovered["ns::obj"].position.x(), 5.0);
     }
 

--- a/crates/core/db/mod.rs
+++ b/crates/core/db/mod.rs
@@ -26,7 +26,6 @@ pub use sync::SyncDB;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-/// Deletes a temporary directory when the last DB clone holding it is dropped.
 struct TempDirGuard(std::path::PathBuf);
 
 impl Drop for TempDirGuard {
@@ -50,7 +49,6 @@ pub struct DB {
     pub(crate) ops_count: Arc<AtomicU64>,
     #[allow(dead_code)] // Will be used for snapshot checkpoints
     pub(crate) config: Config,
-    // Declared last so it drops after `cold` (and its open file handle).
     _temp_dir: Option<Arc<TempDirGuard>>,
 }
 
@@ -182,8 +180,8 @@ impl DB {
         if self.closed.load(Ordering::Acquire) {
             return Err(SpatioError::DatabaseClosed);
         }
-        self.hot.remove_object(namespace, object_id);
         self.cold.append_tombstone(namespace, object_id)?;
+        self.hot.remove_object(namespace, object_id);
         Ok(())
     }
 

--- a/crates/core/db/mod.rs
+++ b/crates/core/db/mod.rs
@@ -26,6 +26,15 @@ pub use sync::SyncDB;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
+/// Deletes a temporary directory when the last DB clone holding it is dropped.
+struct TempDirGuard(std::path::PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
 /// Embedded spatio-temporal database.
 ///
 /// Optimized for tracking moving objects with hot/cold data separation.
@@ -41,6 +50,8 @@ pub struct DB {
     pub(crate) ops_count: Arc<AtomicU64>,
     #[allow(dead_code)] // Will be used for snapshot checkpoints
     pub(crate) config: Config,
+    // Declared last so it drops after `cold` (and its open file handle).
+    _temp_dir: Option<Arc<TempDirGuard>>,
 }
 
 impl DB {
@@ -58,20 +69,23 @@ impl DB {
         let path_ref = path.as_ref();
         let hot = Arc::new(HotState::new());
 
-        let cold = if path_ref.to_str() == Some(":memory:") {
+        let (cold, temp_dir_guard) = if path_ref.to_str() == Some(":memory:") {
             let temp_dir =
                 std::env::temp_dir().join(format!("spatio_mem_{}", uuid::Uuid::new_v4()));
-            Arc::new(ColdState::new(
+            let cold = Arc::new(ColdState::new(
                 &temp_dir.join("traj.log"),
                 config.buffer_capacity,
                 config.persistence.clone(),
-            )?)
+            )?);
+            let guard = Arc::new(TempDirGuard(temp_dir));
+            (cold, Some(guard))
         } else {
-            Arc::new(ColdState::new(
+            let cold = Arc::new(ColdState::new(
                 path_ref,
                 config.buffer_capacity,
                 config.persistence.clone(),
-            )?)
+            )?);
+            (cold, None)
         };
 
         // Recover current locations from cold storage (skip for :memory: mode)
@@ -110,6 +124,7 @@ impl DB {
             closed: Arc::new(AtomicBool::new(false)),
             ops_count: Arc::new(AtomicU64::new(0)),
             config,
+            _temp_dir: temp_dir_guard,
         })
     }
 
@@ -168,6 +183,7 @@ impl DB {
             return Err(SpatioError::DatabaseClosed);
         }
         self.hot.remove_object(namespace, object_id);
+        self.cold.append_tombstone(namespace, object_id)?;
         Ok(())
     }
 
@@ -623,6 +639,67 @@ mod tests {
             .query_trajectory(namespace, object_id, start_time, end_time, 2)
             .unwrap();
         assert_eq!(limited_trajectory.len(), 2);
+    }
+
+    #[test]
+    fn test_delete_does_not_survive_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // First session: insert then delete.
+        {
+            let db = DB::open(&db_path).unwrap();
+            db.upsert("ns", "obj", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), None).unwrap();
+            db.delete("ns", "obj").unwrap();
+            db.close().unwrap();
+        }
+
+        // Second session: object must not reappear.
+        {
+            let db = DB::open(&db_path).unwrap();
+            assert!(db.get("ns", "obj").unwrap().is_none(), "deleted object must not reappear after restart");
+        }
+    }
+
+    #[test]
+    fn test_delete_then_reinsert_survives_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test2.db");
+
+        let pos2 = Point3d::new(9.0, 8.0, 0.0);
+
+        {
+            let db = DB::open(&db_path).unwrap();
+            db.upsert("ns", "obj", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), None).unwrap();
+            db.delete("ns", "obj").unwrap();
+            sleep(Duration::from_millis(1)); // ensure re-insert timestamp > tombstone
+            db.upsert("ns", "obj", pos2.clone(), serde_json::json!({"v": 2}), None).unwrap();
+            db.close().unwrap();
+        }
+
+        {
+            let db = DB::open(&db_path).unwrap();
+            let loc = db.get("ns", "obj").unwrap().expect("re-inserted object must survive restart");
+            assert_eq!(loc.position, pos2);
+        }
+    }
+
+    #[test]
+    fn test_memory_db_cleans_up_temp_dir() {
+        let temp_path = {
+            let db = DB::memory().unwrap();
+            // Reach into the cold state's log path via a query (just to exercise the db)
+            db.upsert("ns", "obj", Point3d::new(0.0, 0.0, 0.0), serde_json::json!({}), None).unwrap();
+            // Extract the temp dir path before dropping
+            match db._temp_dir.as_ref().map(|g| g.0.clone()) {
+                Some(p) => {
+                    assert!(p.exists(), "temp dir must exist while DB is live");
+                    p
+                }
+                None => panic!("memory DB should have a temp dir guard"),
+            }
+        }; // DB dropped here
+        assert!(!temp_path.exists(), "temp dir must be removed after DB is dropped");
     }
 
     #[test]

--- a/crates/core/db/mod.rs
+++ b/crates/core/db/mod.rs
@@ -649,7 +649,14 @@ mod tests {
         // First session: insert then delete.
         {
             let db = DB::open(&db_path).unwrap();
-            db.upsert("ns", "obj", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), None).unwrap();
+            db.upsert(
+                "ns",
+                "obj",
+                Point3d::new(1.0, 2.0, 0.0),
+                serde_json::json!({}),
+                None,
+            )
+            .unwrap();
             db.delete("ns", "obj").unwrap();
             db.close().unwrap();
         }
@@ -657,7 +664,10 @@ mod tests {
         // Second session: object must not reappear.
         {
             let db = DB::open(&db_path).unwrap();
-            assert!(db.get("ns", "obj").unwrap().is_none(), "deleted object must not reappear after restart");
+            assert!(
+                db.get("ns", "obj").unwrap().is_none(),
+                "deleted object must not reappear after restart"
+            );
         }
     }
 
@@ -670,16 +680,27 @@ mod tests {
 
         {
             let db = DB::open(&db_path).unwrap();
-            db.upsert("ns", "obj", Point3d::new(1.0, 2.0, 0.0), serde_json::json!({}), None).unwrap();
+            db.upsert(
+                "ns",
+                "obj",
+                Point3d::new(1.0, 2.0, 0.0),
+                serde_json::json!({}),
+                None,
+            )
+            .unwrap();
             db.delete("ns", "obj").unwrap();
             sleep(Duration::from_millis(1)); // ensure re-insert timestamp > tombstone
-            db.upsert("ns", "obj", pos2.clone(), serde_json::json!({"v": 2}), None).unwrap();
+            db.upsert("ns", "obj", pos2.clone(), serde_json::json!({"v": 2}), None)
+                .unwrap();
             db.close().unwrap();
         }
 
         {
             let db = DB::open(&db_path).unwrap();
-            let loc = db.get("ns", "obj").unwrap().expect("re-inserted object must survive restart");
+            let loc = db
+                .get("ns", "obj")
+                .unwrap()
+                .expect("re-inserted object must survive restart");
             assert_eq!(loc.position, pos2);
         }
     }
@@ -689,7 +710,14 @@ mod tests {
         let temp_path = {
             let db = DB::memory().unwrap();
             // Reach into the cold state's log path via a query (just to exercise the db)
-            db.upsert("ns", "obj", Point3d::new(0.0, 0.0, 0.0), serde_json::json!({}), None).unwrap();
+            db.upsert(
+                "ns",
+                "obj",
+                Point3d::new(0.0, 0.0, 0.0),
+                serde_json::json!({}),
+                None,
+            )
+            .unwrap();
             // Extract the temp dir path before dropping
             match db._temp_dir.as_ref().map(|g| g.0.clone()) {
                 Some(p) => {
@@ -699,7 +727,10 @@ mod tests {
                 None => panic!("memory DB should have a temp dir guard"),
             }
         }; // DB dropped here
-        assert!(!temp_path.exists(), "temp dir must be removed after DB is dropped");
+        assert!(
+            !temp_path.exists(),
+            "temp dir must be removed after DB is dropped"
+        );
     }
 
     #[test]

--- a/crates/py/examples/basic_usage.py
+++ b/crates/py/examples/basic_usage.py
@@ -9,8 +9,6 @@ This example demonstrates the core functionality of Spatio including:
 - Spatial queries
 """
 
-import time
-
 import spatio
 
 
@@ -67,8 +65,6 @@ def _demonstrate_geographic_operations(db):
     for point, city_name in european_cities:
         print(f"  - {city_name.decode()} at ({point.lat:.2f}, {point.lon:.2f})")
     return nyc, london, paris
-
-
 
 
 def _demonstrate_sequential_operations(db):

--- a/crates/py/src/spatio/__init__.py
+++ b/crates/py/src/spatio/__init__.py
@@ -26,23 +26,23 @@ from __future__ import annotations
 
 # Import the compiled Rust extension
 from spatio._spatio import Config as _Config
+from spatio._spatio import DistanceMetric as _DistanceMetric
 from spatio._spatio import Point as _Point
-from spatio._spatio import TemporalPoint as _TemporalPoint
+from spatio._spatio import Polygon as _Polygon
 from spatio._spatio import SetOptions as _SetOptions
 from spatio._spatio import Spatio as _Spatio
-from spatio._spatio import Polygon as _Polygon
-from spatio._spatio import DistanceMetric as _DistanceMetric
+from spatio._spatio import TemporalPoint as _TemporalPoint
 from spatio._spatio import __version__
 
 # Re-export main classes
 __all__ = [
     "Config",
+    "DistanceMetric",
     "Point",
-    "TemporalPoint",
+    "Polygon",
     "SetOptions",
     "Spatio",
-    "Polygon",
-    "DistanceMetric",
+    "TemporalPoint",
     "__version__",
 ]
 

--- a/crates/py/tests/test_full_api.py
+++ b/crates/py/tests/test_full_api.py
@@ -1,67 +1,74 @@
+import time
 
 import pytest
-import spatio
-from spatio import Point, Spatio, TemporalPoint
-import time
+
+from spatio import Point
+from spatio import Spatio
+from spatio import TemporalPoint
+
 
 @pytest.fixture
 def db():
     return Spatio.memory()
 
+
 def test_insert_trajectory(db):
     namespace = "traj_test"
     points = [
-        TemporalPoint(Point(0,0,0), time.time()),
-        TemporalPoint(Point(1,1,0), time.time() + 1),
-        TemporalPoint(Point(2,2,0), time.time() + 2),
+        TemporalPoint(Point(0, 0, 0), time.time()),
+        TemporalPoint(Point(1, 1, 0), time.time() + 1),
+        TemporalPoint(Point(2, 2, 0), time.time() + 2),
     ]
-    
+
     db.insert_trajectory(namespace, "drone1", points)
-    
+
     # Verify current location is the last point
-    locs = db.query_radius(namespace, Point(2,2,0), 0.1)
+    locs = db.query_radius(namespace, Point(2, 2, 0), 0.1)
     assert len(locs) == 1
     assert locs[0][0] == "drone1"
 
+
 def test_bbox_queries(db):
     namespace = "bbox_test"
-    db.upsert(namespace, "p1", Point(0,0,0))
-    db.upsert(namespace, "p2", Point(10,10,0))
-    
+    db.upsert(namespace, "p1", Point(0, 0, 0))
+    db.upsert(namespace, "p2", Point(10, 10, 0))
+
     # 2D BBox
     results = db.query_bbox(namespace, -1, -1, 1, 1)
     assert len(results) == 1
     assert results[0][0] == "p1"
-    
+
     # 3D BBox
-    # p1 is at z=0. 
+    # p1 is at z=0.
     # Query z mainly
     results = db.query_within_bbox_3d(namespace, -1, -1, -1, 1, 1, 1)
     assert len(results) == 1
     assert results[0][0] == "p1"
 
+
 def test_cylinder_query(db):
     namespace = "cyl_test"
     # Ground point
-    db.upsert(namespace, "g1", Point(0,0,0))
+    db.upsert(namespace, "g1", Point(0, 0, 0))
     # Air point (same lat/lon)
-    db.upsert(namespace, "a1", Point(0,0,1000))
-    
+    db.upsert(namespace, "a1", Point(0, 0, 1000))
+
     # Query cylinder: Radius 100m, but only z 500-1500
-    results = db.query_within_cylinder(namespace, Point(0,0,0), 500, 1500, 100)
-    
+    results = db.query_within_cylinder(namespace, Point(0, 0, 0), 500, 1500, 100)
+
     assert len(results) == 1
     assert results[0][0] == "a1"
 
+
 def test_relative_queries(db):
     namespace = "rel_test"
-    db.upsert(namespace, "center", Point(0,0,0))
-    db.upsert(namespace, "target", Point(0,0,10))
-    
+    db.upsert(namespace, "center", Point(0, 0, 0))
+    db.upsert(namespace, "target", Point(0, 0, 10))
+
     # BBox near object
-    results = db.query_bbox_near_object(namespace, "center", 20, 20) # huge box
+    results = db.query_bbox_near_object(namespace, "center", 20, 20)  # huge box
     assert len(results) >= 1
-    
+
     # Cylinder near object
     # Near "center", lookup up z=500..1500 (should be empty)
     results = db.query_cylinder_near_object(namespace, "center", 500, 1500, 10)

--- a/crates/py/tests/test_knn.py
+++ b/crates/py/tests/test_knn.py
@@ -1,76 +1,79 @@
-
 import pytest
-import spatio
-from spatio import Point, Spatio
-import time
+
+from spatio import Point
+from spatio import Spatio
+
 
 @pytest.fixture
 def db():
     return Spatio.memory()
 
+
 def test_knn_basic(db):
     namespace = "knn_test"
     db.upsert(namespace, "center", Point(0, 0, 0), {})
-    
+
     # Add points at increasing distances
     db.upsert(namespace, "p1", Point(0, 1, 0), {"id": 1})  # ~111km
     db.upsert(namespace, "p2", Point(0, 2, 0), {"id": 2})  # ~222km
     db.upsert(namespace, "p3", Point(0, 3, 0), {"id": 3})  # ~333km
-    
+
     # Query 2 nearest from center
     results = db.knn(namespace, Point(0, 0, 0), 2)
-    
+
     assert len(results) == 2
     # Results should be sorted by distance: center (dist=0), p1 (dist=~111km)
     # Note: query point is (0,0,0) which exactly matches "center" object
-    
+
     ids = [r[0] for r in results]
     assert "center" in ids
     assert "p1" in ids
     assert "p2" not in ids
 
+
 def test_knn_near_object(db):
     namespace = "knn_obj_test"
-    
+
     # Drone at (0,0)
     db.upsert(namespace, "drone1", Point(0, 0, 0), {})
-    
+
     # Target 1 at (0.0001, 0)
-    db.upsert(namespace, "target1", Point(0.0001, 0, 0), {}) 
-    
+    db.upsert(namespace, "target1", Point(0.0001, 0, 0), {})
+
     # Target 2 at (10, 10)
     db.upsert(namespace, "target2", Point(10, 10, 0), {})
-    
+
     # Query nearest 1 to drone1
     results = db.knn_near_object(namespace, "drone1", 2)
-    
+
     # Should get drone1 itself (dist=0) and target1
     assert len(results) == 2
     assert results[0][0] == "drone1"
     assert results[1][0] == "target1"
 
+
 def test_knn_3d(db):
     namespace = "knn_3d_test"
-    
+
     # Ground point
     db.upsert(namespace, "ground", Point(0, 0, 0), {})
-    
+
     # Air point (same lat/lon, 1000m up)
     db.upsert(namespace, "air", Point(0, 0, 1000), {})
-    
+
     # Far point (1 degree away)
     db.upsert(namespace, "far", Point(1, 0, 0), {})
-    
+
     # Query from (0,0, 100)
     results = db.knn(namespace, Point(0, 0, 100), 10)
-    
+
     # Check that results were obtained and have valid structure
     assert len(results) >= 2
     ids = [r[0] for r in results]
-    
+
     # due to unweighted R-tree metric (deg vs meters), 'far' (1 deg) is "closer" than 'air' (900m) in the index space.
     # Verify that the wrapper correctly returns 3D points.
     assert "ground" in ids
-    
+
     air_point = next(p for i, p, m, d in results if i == "air")
     assert air_point.z == 1000

--- a/crates/py/tests/test_spatio.py
+++ b/crates/py/tests/test_spatio.py
@@ -5,14 +5,18 @@ Comprehensive tests for Spatio Python bindings
 import gc
 import os
 import time
+
 import pytest
+
 import spatio
+
 
 @pytest.fixture
 def gc_collect():
     """Fixture for test cleanup"""
     yield
     gc.collect()
+
 
 class TestPoint:
     """Test Point class functionality"""
@@ -45,6 +49,7 @@ class TestPoint:
         point = spatio.Point(-74.0060, 40.7128)
         assert "Point(x=-74.0060, y=40.7128, z=0.0000)" in str(point)
 
+
 class TestConfig:
     """Test Config class functionality"""
 
@@ -52,6 +57,7 @@ class TestConfig:
         """Test default configuration"""
         config = spatio.Config()
         assert config is not None
+
 
 class TestSpatio:
     """Test main Spatio database functionality"""
@@ -78,10 +84,10 @@ class TestSpatio:
         """Test updating location"""
         db = spatio.Spatio.memory()
         nyc = spatio.Point(-74.0060, 40.7128)
-        
+
         # Update with metadata
         db.upsert("cities", "nyc", nyc, {"name": "New York"})
-        
+
         # Query to verify
         results = db.query_radius("cities", nyc, 1000.0, 10)
         assert len(results) == 1
@@ -96,9 +102,9 @@ class TestSpatio:
         """Test updating location without metadata"""
         db = spatio.Spatio.memory()
         nyc = spatio.Point(-74.0060, 40.7128)
-        
+
         db.upsert("cities", "nyc", nyc)
-        
+
         results = db.query_radius("cities", nyc, 1000.0, 10)
         assert len(results) == 1
         # Expect (obj_id, point, meta, distance)
@@ -110,23 +116,23 @@ class TestSpatio:
         db = spatio.Spatio.memory()
         nyc = spatio.Point(-74.0060, 40.7128)
         brooklyn = spatio.Point(-73.9442, 40.6782)
-        
+
         db.upsert("cities", "nyc", nyc, {"name": "NYC"})
         db.upsert("cities", "bk", brooklyn, {"name": "Brooklyn"})
-        
+
         # Query near NYC
         results = db.query_near("cities", "nyc", 10000.0, 10)
-        
-        # Should find Brooklyn (NYC itself is excluded from near_object query usually, or included? 
-        # Rust implementation of query_near_object usually excludes the object itself if it's based on KNN, 
-        # but let's check behavior. Actually standard radius query includes it. 
+
+        # Should find Brooklyn (NYC itself is excluded from near_object query usually, or included?
+        # Rust implementation of query_near_object usually excludes the object itself if it's based on KNN,
+        # but let's check behavior. Actually standard radius query includes it.
         # Let's assume it finds neighbors.)
-        
+
         # Based on implementation, it does a radius search around the object's position.
         # It likely includes the object itself unless explicitly filtered.
         # Let's verify count.
         assert len(results) >= 1
-        
+
         found_bk = False
         # Expect (obj_id, point, meta, distance)
         for obj_id, _, _, _ in results:
@@ -137,40 +143,43 @@ class TestSpatio:
     def test_trajectory_operations(self):
         """Test trajectory tracking functionality"""
         db = spatio.Spatio.memory()
-        
+
         start_time = time.time()
-        
+
         # Add points to create trajectory
-        # Note: In a real test we'd want to control timestamps, but the Python API 
+        # Note: In a real test we'd want to control timestamps, but the Python API
         # currently uses system time for updates.
-        
+
         p1 = spatio.Point(-74.0060, 40.7128)
         db.upsert("vehicle", "truck1", p1, {"step": 1})
         time.sleep(0.01)
-        
+
         p2 = spatio.Point(-74.0040, 40.7150)
         db.upsert("vehicle", "truck1", p2, {"step": 2})
         time.sleep(0.01)
-        
+
         end_time = time.time()
-        
+
         # Query trajectory
-        path = db.query_trajectory("vehicle", "truck1", start_time - 1.0, end_time + 1.0, 10)
+        path = db.query_trajectory(
+            "vehicle", "truck1", start_time - 1.0, end_time + 1.0, 10
+        )
         assert len(path) == 2
-        
+
         # Verify order (newest first usually)
         # Rust implementation sorts by timestamp descending
-        assert path[0][1] == {"step": 2} # metadata
+        assert path[0][1] == {"step": 2}  # metadata
         assert path[1][1] == {"step": 1}
 
     def test_close_operation(self):
         """Test database close operation"""
         db = spatio.Spatio.memory()
         db.close()
-        
+
         # Operations should fail after close
         with pytest.raises(RuntimeError, match=r"Database is closed"):
             db.upsert("test", "obj", spatio.Point(0, 0))
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
 1. delete doesn't survive restart (correctness bug)                                                                         
  - Added ColdState::append_tombstone which writes TOMBSTONE|timestamp|namespace|object_id to the log                         
  - recover_current_locations now tracks tombstones and filters out any object whose latest log entry is a tombstone          
  - If an object is re-inserted after deletion (with a newer timestamp), it recovers correctly                      
  - DB::delete now calls cold.append_tombstone after removing from hot state                                                  
  - 4 new tests cover the delete/restart, re-insert/restart, and tombstone-only cold-state scenarios                          
                                                                                                                              
  2. In-memory mode leaks temp directories                                                                                    
  - Added a private TempDirGuard(PathBuf) with a Drop impl that calls fs::remove_dir_all                                      
  - DB now holds _temp_dir: Option<Arc<TempDirGuard>> (declared last so it drops after the ColdState file handle)             
  - For :memory: mode the guard is set; for on-disk mode it's None                                                            
  - New test verifies the temp dir is present while the DB is alive and gone after the last clone is dropped 